### PR TITLE
Add release recipe for automated version tagging

### DIFF
--- a/justfile
+++ b/justfile
@@ -93,5 +93,5 @@ release bump message:
     git push origin "$NEW_VERSION"
 
     echo "Released $NEW_VERSION"
-    REPO=$(git remote get-url origin | sed 's/.*://;s/.git$//')
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
     echo "CI workflow: https://github.com/$REPO/actions"


### PR DESCRIPTION
## Summary

Added a `just release` recipe that automates the complete release process for creating version tags.

The recipe:
- Verifies environment (on main, clean working tree, up to date with remote)
- Calculates next version from latest git tag
- Creates annotated tag with provided message
- Pushes tag to origin to trigger CI publish workflow

Supports major, minor, and patch version bumps.

Closes #20