### PR TITLE
Add distribution mode for parameters

### DIFF
--- a/src/gen_art_framework/distributions.py
+++ b/src/gen_art_framework/distributions.py
@@ -119,7 +119,10 @@ def sample_parameter_space(
 
 
 def _sample_distribution(
-    distribution: str, args: dict[str, Any], rng: np.random.Generator, mode: str = "sample"
+    distribution: str,
+    args: dict[str, Any],
+    rng: np.random.Generator,
+    mode: str = "sample",
 ) -> Any:
     """Sample a single value from a distribution or return a frozen distribution object.
 

--- a/src/gen_art_framework/distributions.py
+++ b/src/gen_art_framework/distributions.py
@@ -10,6 +10,87 @@ import scipy.stats
 from gen_art_framework.schema import ParameterSpace
 
 
+class ConstantDistribution:
+    """Wrapper for constant distribution with scipy-like interface."""
+
+    def __init__(self, value: Any):
+        """Create a constant distribution that always returns the same value.
+
+        Args:
+            value: The constant value to return.
+        """
+        self._value = value
+
+    def rvs(self, size=None):
+        """Sample from the constant distribution.
+
+        Args:
+            size: Optional size parameter (ignored, returns scalar or array of constant).
+
+        Returns:
+            The constant value, or array of constant values if size is specified.
+        """
+        if size is None:
+            return self._value
+        return np.full(size, self._value)
+
+
+class ChoiceDistribution:
+    """Wrapper for choice distribution with scipy-like interface."""
+
+    def __init__(self, values: list, weights: list | None, rng: np.random.Generator):
+        """Create a choice distribution that samples from a set of values.
+
+        Args:
+            values: List of values to choose from.
+            weights: Optional list of weights (must match length of values).
+            rng: Numpy random generator for sampling.
+        """
+        self._values = values
+        self._weights = weights
+        self._rng = rng
+
+    def rvs(self, size=None):
+        """Sample from the choice distribution.
+
+        Args:
+            size: Optional size parameter for number of samples.
+
+        Returns:
+            A single sampled value, or array of sampled values if size is specified.
+        """
+        if size is None:
+            idx = self._rng.choice(len(self._values), p=self._weights)
+            return self._values[idx]
+        indices = self._rng.choice(len(self._values), size=size, p=self._weights)
+        return [self._values[i] for i in indices]
+
+
+class ScipyDistributionWrapper:
+    """Wrapper for scipy distributions with fixed RNG."""
+
+    def __init__(self, frozen_dist, rng: np.random.Generator):
+        """Create a scipy distribution wrapper with fixed RNG.
+
+        Args:
+            frozen_dist: A frozen scipy distribution (created with dist(**args)).
+            rng: Numpy random generator for sampling.
+        """
+        self._frozen_dist = frozen_dist
+        self._rng = rng
+
+    def rvs(self, size=None):
+        """Sample from the scipy distribution.
+
+        Args:
+            size: Optional size parameter for number of samples.
+
+        Returns:
+            A single sampled value, or array of sampled values if size is specified.
+        """
+        return self._frozen_dist.rvs(size=size, random_state=self._rng)
+
+
 def sample_parameter_space(
     space: ParameterSpace, rng: np.random.Generator
 ) -> dict[str, Any]:
@@ -20,7 +101,9 @@ def sample_parameter_space(
         rng: A numpy random generator for reproducible sampling.
 
     Returns:
-        A dictionary mapping parameter names to sampled values.
+        A dictionary mapping parameter names to sampled values or distribution objects.
+        When a parameter has mode="distribution", the value will be a distribution object
+        with a .rvs() method instead of a sampled value.
 
     Raises:
         ValueError: If a distribution name is unknown.
@@ -28,23 +111,26 @@ def sample_parameter_space(
     result = {}
 
     for param in space:
-        result[param.name] = _sample_distribution(param.distribution, param.args, rng)
+        result[param.name] = _sample_distribution(
+            param.distribution, param.args, rng, mode=param.mode
+        )
 
     return result
 
 
 def _sample_distribution(
-    distribution: str, args: dict[str, Any], rng: np.random.Generator
+    distribution: str, args: dict[str, Any], rng: np.random.Generator, mode: str = "sample"
 ) -> Any:
-    """Sample a single value from a distribution.
+    """Sample a single value from a distribution or return a frozen distribution object.
 
     Args:
         distribution: The name of the distribution.
         args: Arguments to pass to the distribution.
         rng: A numpy random generator.
+        mode: Either "sample" (returns a sampled value) or "distribution" (returns a distribution object).
 
     Returns:
-        A sampled value.
+        A sampled value (if mode="sample") or a distribution object with .rvs() method (if mode="distribution").
 
     Raises:
         ValueError: If the distribution name is unknown.
@@ -53,7 +139,10 @@ def _sample_distribution(
     if distribution == "constant":
         if "value" not in args:
             raise ValueError("'constant' distribution requires a 'value' argument.")
-        return args["value"]
+        value = args["value"]
+        if mode == "distribution":
+            return ConstantDistribution(value)
+        return value
 
     if distribution == "choice":
         if "values" not in args:
@@ -69,6 +158,8 @@ def _sample_distribution(
                 f"'choice' distribution 'weights' length ({len(weights)}) "
                 f"must match 'values' length ({len(values)})."
             )
+        if mode == "distribution":
+            return ChoiceDistribution(values, weights, rng)
         idx = rng.choice(len(values), p=weights)
         return values[idx]
 
@@ -81,5 +172,9 @@ def _sample_distribution(
             f"Unknown distribution '{distribution}'. "
             f"Must be 'constant', 'choice', or a valid scipy.stats distribution."
         )
+
+    if mode == "distribution":
+        frozen_dist = dist(**args)
+        return ScipyDistributionWrapper(frozen_dist, rng)
 
     return dist.rvs(random_state=rng, **args)

--- a/src/gen_art_framework/distributions.py
+++ b/src/gen_art_framework/distributions.py
@@ -63,7 +63,7 @@ class ChoiceDistribution:
             idx = self._rng.choice(len(self._values), p=self._weights)
             return self._values[idx]
         indices = self._rng.choice(len(self._values), size=size, p=self._weights)
-        return [self._values[i] for i in indices]
+        return np.array([self._values[i] for i in indices])
 
 
 class ScipyDistributionWrapper:

--- a/src/gen_art_framework/schema.py
+++ b/src/gen_art_framework/schema.py
@@ -94,19 +94,21 @@ def _validate_parameter(param_dict: dict[str, Any]) -> ParameterDefinition:
 
     # Extract and validate mode
     mode = param_dict.get("mode", "sample")
-    if not isinstance(mode, str):
+    # Convert to string for validation
+    mode_str = str(mode)
+    if mode_str not in ("sample", "distribution"):
         raise ValueError(
-            f"Parameter '{name}' 'mode' must be a string, got {type(mode).__name__}"
-        )
-    if mode not in ("sample", "distribution"):
-        raise ValueError(
-            f"Parameter '{name}' 'mode' must be 'sample' or 'distribution', got '{mode}'"
+            f"Parameter '{name}' 'mode' must be 'sample' or 'distribution', got '{mode_str}'"
         )
 
     # Extract args (everything except name, distribution, and mode)
-    args = {k: v for k, v in param_dict.items() if k not in ("name", "distribution", "mode")}
+    args = {
+        k: v for k, v in param_dict.items() if k not in ("name", "distribution", "mode")
+    }
 
-    return ParameterDefinition(name=name, distribution=distribution, args=args, mode=mode)
+    return ParameterDefinition(
+        name=name, distribution=distribution, args=args, mode=mode_str
+    )
 
 
 def parse_parameter_space(docstring: str) -> ParameterSpace:

--- a/src/gen_art_framework/schema.py
+++ b/src/gen_art_framework/schema.py
@@ -20,6 +20,7 @@ class ParameterDefinition:
     name: str
     distribution: str
     args: dict[str, Any]
+    mode: str = "sample"
 
 
 @dataclass
@@ -91,10 +92,21 @@ def _validate_parameter(param_dict: dict[str, Any]) -> ParameterDefinition:
             f"Parameter name '{name}' is reserved (shadows a Python builtin or keyword)"
         )
 
-    # Extract args (everything except name and distribution)
-    args = {k: v for k, v in param_dict.items() if k not in ("name", "distribution")}
+    # Extract and validate mode
+    mode = param_dict.get("mode", "sample")
+    if not isinstance(mode, str):
+        raise ValueError(
+            f"Parameter '{name}' 'mode' must be a string, got {type(mode).__name__}"
+        )
+    if mode not in ("sample", "distribution"):
+        raise ValueError(
+            f"Parameter '{name}' 'mode' must be 'sample' or 'distribution', got '{mode}'"
+        )
 
-    return ParameterDefinition(name=name, distribution=distribution, args=args)
+    # Extract args (everything except name, distribution, and mode)
+    args = {k: v for k, v in param_dict.items() if k not in ("name", "distribution", "mode")}
+
+    return ParameterDefinition(name=name, distribution=distribution, args=args, mode=mode)
 
 
 def parse_parameter_space(docstring: str) -> ParameterSpace:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -277,6 +277,93 @@ class TestValidationErrors:
             parse_parameter_space(docstring)
 
 
+class TestModeValidation:
+    """Tests for mode field validation."""
+
+    def test_mode_defaults_to_sample(self):
+        """Mode field defaults to 'sample' when not specified."""
+        docstring = dedent("""
+            parameters:
+              - name: x
+                distribution: uniform
+                loc: 0
+                scale: 1
+        """)
+        result = parse_parameter_space(docstring)
+        assert result["x"].mode == "sample"
+
+    def test_explicit_sample_mode(self):
+        """Mode field can be explicitly set to 'sample'."""
+        docstring = dedent("""
+            parameters:
+              - name: x
+                distribution: uniform
+                loc: 0
+                scale: 1
+                mode: sample
+        """)
+        result = parse_parameter_space(docstring)
+        assert result["x"].mode == "sample"
+
+    def test_explicit_distribution_mode(self):
+        """Mode field can be explicitly set to 'distribution'."""
+        docstring = dedent("""
+            parameters:
+              - name: x
+                distribution: uniform
+                loc: 0
+                scale: 1
+                mode: distribution
+        """)
+        result = parse_parameter_space(docstring)
+        assert result["x"].mode == "distribution"
+
+    def test_invalid_mode_raises(self):
+        """Raises ValueError when mode is not 'sample' or 'distribution'."""
+        docstring = dedent("""
+            parameters:
+              - name: x
+                distribution: uniform
+                loc: 0
+                scale: 1
+                mode: invalid
+        """)
+        with pytest.raises(
+            ValueError, match="'mode' must be 'sample' or 'distribution', got 'invalid'"
+        ):
+            parse_parameter_space(docstring)
+
+    def test_non_string_mode_raises(self):
+        """Raises ValueError when mode is not 'sample' or 'distribution'."""
+        docstring = dedent("""
+            parameters:
+              - name: x
+                distribution: uniform
+                loc: 0
+                scale: 1
+                mode: 123
+        """)
+        with pytest.raises(
+            ValueError, match="'mode' must be 'sample' or 'distribution', got '123'"
+        ):
+            parse_parameter_space(docstring)
+
+    def test_mode_not_in_args(self):
+        """Mode field is not included in parameter args."""
+        docstring = dedent("""
+            parameters:
+              - name: x
+                distribution: uniform
+                loc: 0
+                scale: 1
+                mode: distribution
+        """)
+        result = parse_parameter_space(docstring)
+        assert "mode" not in result["x"].args
+        assert "loc" in result["x"].args
+        assert "scale" in result["x"].args
+
+
 class TestParameterSpace:
     """Tests for ParameterSpace container functionality."""
 


### PR DESCRIPTION
## Summary

Implements distribution mode for parameters, enabling scripts to sample multiple values from the same distribution whilst maintaining reproducibility.

**Key changes:**
- Parameters can now specify `mode: distribution` to receive distribution objects instead of sampled values
- Distribution objects provide `.rvs()` method for sampling (scipy-like interface)
- All distribution types supported: constant, choice, and scipy distributions
- Reproducible sampling with RNG seeding
- Mixed mode support (some parameters sampled, others as distributions)

**Implementation:**
- Added `mode` field to `ParameterDefinition` schema with validation
- Created wrapper classes: `ConstantDistribution`, `ChoiceDistribution`, `ScipyDistributionWrapper`
- Extended `_sample_distribution()` to support both modes
- Comprehensive test coverage (9 unit tests + 3 integration tests)
- Documented in `docs/distributions.md` with examples

Closes #22