### PR TITLE
Add install-example CLI command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI Usage
 
-The `gen-art` command-line tool generates images by sampling from parameterised scripts.
+The `gen-art` command-line tool generates images by sampling from parameterised scripts and provides example scripts to help you get started.
 
 ## Commands
 
@@ -24,7 +24,52 @@ gen-art sample SCRIPT [OPTIONS]
 | `--output` | `-o` | `.` | Output directory for generated images |
 | `--seed` | `-s` | random | Random seed for reproducibility |
 
-## Output Filenames
+### `gen-art install-example`
+
+Copy example scripts from the package to your filesystem.
+
+```bash
+gen-art install-example EXAMPLE [OPTIONS]
+```
+
+**Arguments:**
+
+- `EXAMPLE` - Name of an example to install, or `all` to install all available examples
+
+**Options:**
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | `.` | Output directory for example files |
+
+**Available Examples:**
+
+- `circles` - Simple generative art with random circles
+- `flow_field` - Complex flow field animation using noise functions
+
+**Overwrite Protection:**
+
+The command will not overwrite existing files. If a file already exists at the target location, it will be skipped with a warning message.
+
+**Examples:**
+
+```bash
+# Install a single example to current directory
+gen-art install-example circles
+
+# Install all examples
+gen-art install-example all
+
+# Install to a specific directory
+gen-art install-example flow_field -o ./examples
+
+# Install all examples to a custom location
+gen-art install-example all --output ./my-scripts
+```
+
+## Sample Command Details
+
+### Output Filenames
 
 Generated images follow the naming pattern:
 
@@ -44,7 +89,7 @@ circles_1_9283746192.png
 circles_2_3847291028.png
 ```
 
-## Reproducibility
+### Reproducibility
 
 Use the `--seed` option to generate reproducible results:
 
@@ -54,7 +99,7 @@ gen-art sample my_script.py -n 5 -s 42
 gen-art sample my_script.py -n 5 -s 42
 ```
 
-### Two-Level Seeding
+#### Two-Level Seeding
 
 When you provide `--seed`, the CLI uses a two-level seeding mechanism:
 
@@ -78,7 +123,7 @@ Generating image 1/1...
 Generated 1 image(s) in .
 ```
 
-## Examples
+### Examples
 
 ```bash
 # Generate a single image in the current directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ build-backend = "hatchling.build"
 [tool.hatch.version]
 source = "uv-dynamic-versioning"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/gen_art_framework"]
+include = ["src/gen_art_framework/examples/*.py"]
+
 [dependency-groups]
 dev = [
     "ipython>=9.8.0",
@@ -51,3 +55,6 @@ dev = [
     "pytest-cov>=7.0.0",
     "ruff>=0.14.10",
 ]
+
+[tool.ruff]
+extend-exclude = ["src/gen_art_framework/examples/*.py"]

--- a/src/gen_art_framework/examples/__init__.py
+++ b/src/gen_art_framework/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Example scripts for generative art."""

--- a/src/gen_art_framework/examples/circles.py
+++ b/src/gen_art_framework/examples/circles.py
@@ -1,0 +1,39 @@
+"""
+parameters:
+  - name: width
+    distribution: constant
+    value: 800
+  - name: height
+    distribution: constant
+    value: 600
+  - name: num_circles
+    distribution: randint
+    low: 20
+    high: 50
+  - name: seed
+    distribution: randint
+    low: 0
+    high: 10000
+  - name: background
+    distribution: choice
+    values: ["#1a1a2e", "#16213e", "#0f3460"]
+  - name: colour
+    distribution: choice
+    values: ["#e94560", "#f39c12", "#00b894", "#6c5ce7"]
+"""
+
+from PIL import Image, ImageDraw
+import random
+
+random.seed(seed)
+
+img = Image.new("RGB", (width, height), background)
+draw = ImageDraw.Draw(img)
+
+for _ in range(num_circles):
+    x = random.randint(0, width)
+    y = random.randint(0, height)
+    r = random.randint(10, 50)
+    draw.ellipse([x - r, y - r, x + r, y + r], fill=colour)
+
+img

--- a/src/gen_art_framework/examples/circles.py
+++ b/src/gen_art_framework/examples/circles.py
@@ -20,6 +20,12 @@ parameters:
   - name: colour
     distribution: choice
     values: ["#e94560", "#f39c12", "#00b894", "#6c5ce7"]
+    mode: distribution
+  - name: radius
+    distribution: randint
+    low: 10
+    high: 50
+    mode: distribution
 """
 
 from PIL import Image, ImageDraw
@@ -33,7 +39,8 @@ draw = ImageDraw.Draw(img)
 for _ in range(num_circles):
     x = random.randint(0, width)
     y = random.randint(0, height)
-    r = random.randint(10, 50)
-    draw.ellipse([x - r, y - r, x + r, y + r], fill=colour)
+    r = int(radius.rvs())
+    c = colour.rvs()
+    draw.ellipse([x - r, y - r, x + r, y + r], fill=c)
 
 img

--- a/src/gen_art_framework/examples/flow_field.py
+++ b/src/gen_art_framework/examples/flow_field.py
@@ -1,0 +1,104 @@
+"""
+parameters:
+  - name: width
+    distribution: constant
+    value: 1000
+  - name: height
+    distribution: constant
+    value: 800
+  - name: seed
+    distribution: randint
+    low: 0
+    high: 100000
+  - name: background
+    distribution: choice
+    values: ["#0d1117", "#1a1a2e", "#2d132c", "#0a192f"]
+  - name: line_colour
+    distribution: choice
+    values: ["#00d4ff", "#ff6b6b", "#c9f364", "#f8b500", "#7c3aed", "#06ffa5"]
+  - name: num_lines
+    distribution: randint
+    low: 400
+    high: 900
+  - name: line_length
+    distribution: randint
+    low: 80
+    high: 200
+  - name: line_width
+    distribution: randint
+    low: 1
+    high: 3
+  - name: line_alpha
+    distribution: uniform
+    loc: 0.3
+    scale: 0.5
+  - name: noise_scale
+    distribution: uniform
+    loc: 0.003
+    scale: 0.012
+  - name: noise_offset
+    distribution: uniform
+    loc: 0
+    scale: 100
+  - name: turbulence
+    distribution: uniform
+    loc: 0.8
+    scale: 1.5
+  - name: step_size
+    distribution: uniform
+    loc: 2
+    scale: 4
+"""
+
+from PIL import Image, ImageDraw
+import math
+import random
+
+random.seed(seed)
+
+img = Image.new("RGBA", (width, height), background)
+draw = ImageDraw.Draw(img)
+
+
+def noise_angle(x, y, scale, offset):
+    nx = x * scale + offset
+    ny = y * scale + offset
+    return (
+        math.sin(nx * 1.5) * math.cos(ny * 1.5) +
+        math.sin(nx * 0.7 + ny * 0.5) * 0.5 +
+        math.cos(nx * 0.3 - ny * 0.8) * 0.3
+    ) * math.pi * turbulence
+
+
+def draw_flow_line(start_x, start_y):
+    x, y = start_x, start_y
+    points = [(x, y)]
+
+    for _ in range(line_length):
+        angle = noise_angle(x, y, noise_scale, noise_offset)
+        x += math.cos(angle) * step_size
+        y += math.sin(angle) * step_size
+
+        if x < 0 or x >= width or y < 0 or y >= height:
+            break
+        points.append((x, y))
+
+    if len(points) > 1:
+        for i in range(len(points) - 1):
+            progress = i / len(points)
+            alpha = int(255 * (1 - progress) * line_alpha)
+            colour_with_alpha = line_colour + f"{alpha:02x}"
+            draw.line([points[i], points[i + 1]], fill=colour_with_alpha, width=line_width)
+
+
+grid_size = int(math.sqrt(num_lines))
+spacing_x = width / grid_size
+spacing_y = height / grid_size
+
+for i in range(grid_size):
+    for j in range(grid_size):
+        x = i * spacing_x + random.uniform(-spacing_x * 0.3, spacing_x * 0.3)
+        y = j * spacing_y + random.uniform(-spacing_y * 0.3, spacing_y * 0.3)
+        draw_flow_line(x, y)
+
+img

--- a/src/gen_art_framework/examples/flow_field.py
+++ b/src/gen_art_framework/examples/flow_field.py
@@ -16,6 +16,7 @@ parameters:
   - name: line_colour
     distribution: choice
     values: ["#00d4ff", "#ff6b6b", "#c9f364", "#f8b500", "#7c3aed", "#06ffa5"]
+    mode: distribution
   - name: num_lines
     distribution: randint
     low: 400
@@ -24,14 +25,17 @@ parameters:
     distribution: randint
     low: 80
     high: 200
+    mode: distribution
   - name: line_width
     distribution: randint
     low: 1
     high: 3
+    mode: distribution
   - name: line_alpha
     distribution: uniform
     loc: 0.3
     scale: 0.5
+    mode: distribution
   - name: noise_scale
     distribution: uniform
     loc: 0.003
@@ -74,7 +78,13 @@ def draw_flow_line(start_x, start_y):
     x, y = start_x, start_y
     points = [(x, y)]
 
-    for _ in range(line_length):
+    # Sample line properties for this line
+    length = int(line_length.rvs())
+    lwidth = int(line_width.rvs())
+    alpha_mult = line_alpha.rvs()
+    colour = line_colour.rvs()
+
+    for _ in range(length):
         angle = noise_angle(x, y, noise_scale, noise_offset)
         x += math.cos(angle) * step_size
         y += math.sin(angle) * step_size
@@ -86,9 +96,9 @@ def draw_flow_line(start_x, start_y):
     if len(points) > 1:
         for i in range(len(points) - 1):
             progress = i / len(points)
-            alpha = int(255 * (1 - progress) * line_alpha)
-            colour_with_alpha = line_colour + f"{alpha:02x}"
-            draw.line([points[i], points[i + 1]], fill=colour_with_alpha, width=line_width)
+            alpha = int(255 * (1 - progress) * alpha_mult)
+            colour_with_alpha = colour + f"{alpha:02x}"
+            draw.line([points[i], points[i + 1]], fill=colour_with_alpha, width=lwidth)
 
 
 grid_size = int(math.sqrt(num_lines))


### PR DESCRIPTION
## Summary

Implements a new `install-example` CLI command that allows users to easily copy example scripts from the package to their local filesystem.

- Created `src/gen_art_framework/examples/` directory with two example scripts: `circles.py` and `flow_field.py`
- Added `install-example` command with support for installing single examples or all examples at once
- Implemented overwrite protection to prevent accidentally replacing existing files
- Added comprehensive tests covering all functionality
- Configured package data and ruff to handle example files correctly

Closes #25