### PR TITLE
Document release process in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,24 @@ Run `just` to see available commands (test, lint, format, shell, jupyter).
 - Add dev deps: `uv add --dev <package>`
 - Run anything: `uv run <command>`
 
+## Releases
+
+Use the `just release` command to create new releases:
+
+```bash
+just release <major|minor|patch> "Release message"
+```
+
+- **patch**: Bug fixes and small improvements (0.2.0 → 0.2.1)
+- **minor**: New features, backwards compatible (0.2.0 → 0.3.0)
+- **major**: Breaking changes (0.2.0 → 1.0.0)
+
+The command will:
+1. Verify you're on main with a clean, up-to-date working tree
+2. Calculate the new version based on the latest tag
+3. Create and push a git tag
+4. Trigger the CI workflow to publish to PyPI
+
 ## Code Style
 
 - Keep imports at module level unless there's a meaningful reason not to (e.g. circular imports, optional dependencies)


### PR DESCRIPTION
## Summary

Adds documentation for the release process using `just release` command.

- Documents the three bump levels (major/minor/patch)
- Explains what the release command does
- Provides usage examples